### PR TITLE
Explicit versions in depencencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,46 +39,46 @@
         <dependency>
              <groupId>com.github.marschall</groupId>
              <artifactId>memoryfilesystem</artifactId>
-             <version>[0.8.0,)</version>
+             <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-core</artifactId>
-            <version>[1,2)</version>
+            <version>1.7.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit-dep</artifactId>
-            <version>[4.9,)</version>
+            <version>4.12</version>
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>fishbowl</artifactId>
-            <version>[1.4.1]</version>
+            <version>1.4.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>[0.1.54]</version>
+            <version>0.1.54</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>[2.6]</version>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>[3.9.1]</version>
+            <version>3.9.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>[1.7.25]</version>
+            <version>1.7.25</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         </dependency>
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
-            <version>4.12</version>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>


### PR DESCRIPTION
Changed dependencies version from range to explicit due to long dependency resolve(timeouts appears in slow repository manager) and it should be avoided
Example timeout on slow repo:
```Java
Caused by: org.gradle.api.resources.ResourceException: Unable to load Maven meta-data from http://some-repo.com/artifactory/repo/org/apache/sshd/sshd-core/maven-metadata.xml.
```