### PR TITLE
Support for newest sshd libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>fake-sftp-server-rule</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>3.0.0-Gigaset</version>
     <packaging>jar</packaging>
 
     <name>Fake SFTP Server Rule</name>
@@ -44,7 +44,12 @@
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-core</artifactId>
-            <version>[1,2)</version>
+            <version>[2.6,)</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-sftp</artifactId>
+            <version>[2.6,)</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -60,7 +65,7 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>[0.1.54]</version>
+            <version>[0.1.55]</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>fake-sftp-server-rule</artifactId>
-    <version>3.0.0-Gigaset</version>
+    <version>2.2.0</version>
     <packaging>jar</packaging>
 
     <name>Fake SFTP Server Rule</name>


### PR DESCRIPTION
Since version 2.6.0 of sshd-core library, there has been some changes to class names and package structure, and fake-sftp-server-rule stopped to be compatible with newest versions of this library. This change ensures support for sshd-core > 2.6.0 (Used e.g. by sftp integration of Spring Boot 3)