### PR TITLE
Support for Apache sshd 2.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .flattened-pom.xml
 target
+/.classpath
+/.project
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,12 @@
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-core</artifactId>
-            <version>[1,2)</version>
+            <version>2.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-sftp</artifactId>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -60,7 +65,7 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>[0.1.54]</version>
+            <version>[0.1.55]</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I have updated the code to be compatible with current versions of Apache SSHD (2.9.2 to be specific).

I had to update the unit test because for some reason the usage of `Path.get()` and `.getParent()` on Windows did not work for me anymore. I didn't analyze that too deeply, since it's "just" test code and just switched it to a regular expression.